### PR TITLE
Spike/GP-135 move form templates across accounts

### DIFF
--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -234,6 +234,92 @@
         }
       }
     },
+    "/accounts/{account_id}/form_templates": {
+      "get": {
+        "summary": "Get account form templates",
+        "description": "Get account form templates",
+        "operationId": "getFormTemplates",
+        "tags": [
+          "Form Templates"
+        ],
+        "security": [
+          {
+            "userSessionKey": [],
+            "chillipharmSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            },
+            "description": "The account id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "description": "The form template id",
+                        "example": 1
+                      },
+                      "title": {
+                        "type": "string",
+                        "description": "The form template title",
+                        "example": "Form template title"
+                      },
+                      "fields": {
+                        "type": "array",
+                        "description": "The form template fields",
+                        "items": {
+                          "$ref": "#/components/schemas/FormTemplateField"
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "title",
+                      "fields"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/accounts/{account_id}/form_templates/{form_template_id}": {
       "get": {
         "summary": "Get an account form template",

--- a/public/refs/paths/accounts_{account_id}_form_templates.json
+++ b/public/refs/paths/accounts_{account_id}_form_templates.json
@@ -1,0 +1,80 @@
+{
+  "get": {
+    "summary": "Get account form templates",
+    "description": "Get account form templates",
+    "operationId": "getFormTemplates",
+    "tags": ["Form Templates"],
+    "security": [
+      {
+        "userSessionKey": [],
+        "chillipharmSession": []
+      }
+    ],
+    "parameters": [
+      {
+        "name": "account_id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "1"
+        },
+        "description": "The account id"
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "OK",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "description": "The form template id",
+                    "example": 1
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "The form template title",
+                    "example": "Form template title"
+                  },
+                  "fields": {
+                    "type": "array",
+                    "description": "The form template fields",
+                    "items": {
+                      "$ref": "../components/schemas/FormTemplateField.json"
+                    }
+                  }
+                },
+                "required": ["id", "title", "fields"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "400": {
+        "$ref": "../components/responses/BadRequest.json"
+      },
+      "401": {
+        "$ref": "../components/responses/Unauthorized.json"
+      },
+      "403": {
+        "$ref": "../components/responses/Forbidden.json"
+      },
+      "404": {
+        "$ref": "../components/responses/NotFound.json"
+      },
+      "409": {
+        "$ref": "../components/responses/Conflict.json"
+      },
+      "500": {
+        "$ref": "../components/responses/InternalServerError.json"
+      }
+    }
+  }
+}

--- a/public/schema.json
+++ b/public/schema.json
@@ -63,6 +63,9 @@
     "/accounts/{account_id}/chapter_definitions": {
       "$ref": "refs/paths/accounts_{account_id}_chapter_definitions.json"
     },
+    "/accounts/{account_id}/form_templates": {
+      "$ref": "refs/paths/accounts_{account_id}_form_templates.json"
+    },
     "/accounts/{account_id}/form_templates/{form_template_id}": {
       "$ref": "refs/paths/accounts_{account_id}_form_templates_{form_template_id}.json"
     },


### PR DESCRIPTION
# Version

- Spike to move form templates across accounts
- Need endpoint to fetch all account form templates

# Ticket URL

-

# Changes Made

-

# Checklist

Please verify this checklist so that you are sure this is ready for review.

- [ ] Updated `package.json` & `schema.json` versions - they need to be the same
- [ ] Verify there are no issues with the schema.json by running `npm run verify`
- [ ] All objects have a properites list, `required` array and `additionalProperties` set to `false`
